### PR TITLE
Fix gh-pages CNAME being wiped on every build (#5)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -29,10 +29,14 @@ build() {
 }
 
 setup_gh() {
-  if [[ -z $(git branch -av | grep "$PAGES_BRANCH") ]]; then
-    git checkout -b "$PAGES_BRANCH"
-  else
+  # actions/checkout@v4 only fetches the triggering branch by default, so we
+  # must explicitly pull the existing gh-pages branch from origin to preserve
+  # files that only live there (e.g. CNAME for GitHub Pages custom domains).
+  if git ls-remote --exit-code --heads origin "$PAGES_BRANCH" >/dev/null 2>&1; then
+    git fetch origin "$PAGES_BRANCH":"$PAGES_BRANCH"
     git checkout "$PAGES_BRANCH"
+  else
+    git checkout -b "$PAGES_BRANCH"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Fixes #5 — adding a CNAME on the `gh-pages` branch for a custom domain gets wiped on every push to `main`.
- Root cause: `actions/checkout@v4` defaults to `fetch-depth: 1` and only fetches the triggering branch, so `git branch -av | grep gh-pages` finds nothing. `setup_gh` then takes the `git checkout -b gh-pages` path, creating a fresh branch from `main` without the existing `CNAME`. The backup step finds no `CNAME` to preserve, and the final `--force` push overwrites the remote branch, removing the custom domain.
- Fix: in `setup_gh`, check the remote with `git ls-remote` and `git fetch` the existing `gh-pages` branch before checkout so `CNAME` (and any other files only living on `gh-pages`) end up in the working tree and survive the deploy.

## Test plan
- [x] On a fresh fork: enable GitHub Pages with custom domain on `gh-pages` (creates `CNAME`), push a trivial change to `main`, verify the action run leaves `CNAME` on `gh-pages` and the custom domain stays configured.
- [x] On a brand-new repo with no `gh-pages` yet: first run still creates `gh-pages` (the `else` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)