### PR TITLE
Force-checkout gh-pages so cache writes don't abort deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,7 +34,10 @@ setup_gh() {
   # files that only live there (e.g. CNAME for GitHub Pages custom domains).
   if git ls-remote --exit-code --heads origin "$PAGES_BRANCH" >/dev/null 2>&1; then
     git fetch origin "$PAGES_BRANCH":"$PAGES_BRANCH"
-    git checkout "$PAGES_BRANCH"
+    # build() refreshes tracked cache files (.linkyee-cache/*.json); force the
+    # checkout so those throwaway modifications don't block the switch. flush()
+    # wipes everything except _output/, .git, and CNAME anyway.
+    git checkout -f "$PAGES_BRANCH"
   else
     git checkout -b "$PAGES_BRANCH"
   fi


### PR DESCRIPTION
## Summary
- Hot-fix for the CI break introduced by #6.
- `build()` refreshes tracked cache files (`.linkyee-cache/*.json`) before `setup_gh()` runs. After #6 switched `setup_gh` from `git checkout -b gh-pages` (new branch from current HEAD, no conflict check) to `git checkout gh-pages` (existing branch), the dirty working tree aborts checkout:
  ```
  error: Your local changes to the following files would be overwritten by checkout:
      .linkyee-cache/...
  ```
- Use `git checkout -f` to discard the cache mutations. They're throwaway — `flush()` wipes everything except `_output/`, `.git`, and `CNAME` either way, so this matches the prior behavior.
- `_output/` is gitignored, so `-f` doesn't touch it; `CNAME` comes from the gh-pages checkout itself, so it's still preserved.

## Test plan
- [ ] Merge and watch the next scheduled / push-triggered `Automatic build` run go green.
- [ ] On a fork with a custom domain on `gh-pages`, verify `CNAME` still survives a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)